### PR TITLE
fixed an inline linkage issue.

### DIFF
--- a/vp4c.c
+++ b/vp4c.c
@@ -283,7 +283,7 @@ unsigned TEMPLATE2(_P4BITS, USIZE)(uint_t *__restrict in, unsigned n, unsigned *
 } 
    #endif
  
-inline unsigned char *TEMPLATE2(_P4ENC, USIZE)(uint_t *__restrict in, unsigned n, unsigned char *__restrict out, unsigned b, unsigned bx) {
+unsigned char *TEMPLATE2(_P4ENC, USIZE)(uint_t *__restrict in, unsigned n, unsigned char *__restrict out, unsigned b, unsigned bx) {
   if(!bx) 
     return TEMPLATE2(BITPACK, USIZE)(in, n,	out, b);
 


### PR DESCRIPTION
The `inline` keyword in `vp4c.c`(see the commit) causes my compiler to stop emitting extern symbols for _p4enc* functions, which brings the following linking error:

Environment: Arch Linux 4.11.3, gcc 7.1.1, GNU make 4.2.1

~~~~
$ make AVX2=1
g++ ext/streamvbyte/src/streamvbyte.o ext/streamvbyte/src/streamvbytedelta.o ext/MaskedVByte/src/varintencode.o ext/MaskedVByte/src/varintdecode.o ext/simdcomp/src/simdintegratedbitpacking.o ext/simdcomp/src/simdcomputil.o ext/simdcomp/src/simdbitpacking.o ext/simdcomp/src/simdpackedselect.o ext/simdcomp_/simdfor.o ext/LittleIntPacker/src/bitpacking32.o ext/LittleIntPacker/src/turbobitpacking32.o ext/LittleIntPacker/src/scpacking32.o ext/LittleIntPacker/src/horizontalpacking32.o ext/libfor/for.o ext/bench_/bench/compress_qmx.o ext/bench_/bench/compress_qmx_v2.o ext/bench_/bench/compress_qmx_v3.o ext/bench_/bench/compress_qmx_v4.o ext/varintg8iu.o ext/rc.o ext/polycom/optpfd.o ext/polycom/polyvbyte.o ext/FastPFor/src/bitpacking.o ext/FastPFor/src/simdbitpacking.o ext/FastPFor/src/simdunalignedbitpacking.o ext/lz4/lib/lz4hc.o ext/lz4/lib/lz4.o ext/bitshuffle/src/bitshuffle.o ext/bitshuffle/src/iochain.o ext/bitshuffle/src/bitshuffle_core.o eliasfano.o vsimple.o ext/simple8b.o transpose.o transpose_sse.o bitpack.o bitunpack.o vint.o vp4d.o vp4c.o bitutil.o fp.o icbench.o plugins.o -lpthread -lrt -lz -o icbench

...
vp4c.o: In function `p4enc8':
vp4c.c:(.text+0x3320): undefined reference to `_p4enc8'
vp4c.o: In function `p4nenc8':
vp4c.c:(.text+0x3448): undefined reference to `_p4enc8'
vp4c.o: In function `p4enc16':
vp4c.c:(.text+0x3763): undefined reference to `_p4enc16'
vp4c.o: In function `p4nenc16':
vp4c.c:(.text+0x38ba): undefined reference to `_p4enc16'
...
~~~~

Removing the inline keyword in `vp4c.c` solves the problem. A better solution would be to move the definition of _p4enc* functions to the header file, so that there is one inline definition of the function in each translation unit, allowing better compiler optimization.

