### PR TITLE
msvc fixes

### DIFF
--- a/bitpack_avx2.c
+++ b/bitpack_avx2.c
@@ -1,0 +1,2 @@
+#define AVX2_ON
+#include "bitpack.c"

--- a/bitpack_sse.c
+++ b/bitpack_sse.c
@@ -1,0 +1,2 @@
+#define SSE2_ON
+#include "bitpack.c"

--- a/bitunpack.c
+++ b/bitunpack.c
@@ -764,7 +764,7 @@ size_t bitnfunpack128v32( unsigned char *__restrict in, size_t n, uint32_t *__re
 #define mm256_maskz_expand_epi32(_m_,_v_) _mm256_maskz_expand_epi32(_m_,_v_)
 #define mm256_maskz_loadu_epi32( _m_,_v_) _mm256_maskz_loadu_epi32( _m_,_v_)
   #else
-static unsigned char permv[256][8] __attribute__((aligned(32))) = {
+static ALIGNED(unsigned char, permv[256][8], 32) = {
 0,0,0,0,0,0,0,0,
 0,1,1,1,1,1,1,1,
 1,0,1,1,1,1,1,1,

--- a/bitunpack_avx2.c
+++ b/bitunpack_avx2.c
@@ -1,0 +1,2 @@
+#define AVX2_ON
+#include "bitunpack.c"

--- a/bitunpack_sse.c
+++ b/bitunpack_sse.c
@@ -1,0 +1,2 @@
+#define SSE2_ON
+#include "bitunpack.c"

--- a/conf.h
+++ b/conf.h
@@ -85,7 +85,7 @@ static inline unsigned short bswap16(unsigned short x) { return __builtin_bswap3
 #define __builtin_prefetch(x,a) _mm_prefetch(x, _MM_HINT_NTA)
     #endif
 	
-#define ALIGNED(x)		__declspec(align(x))
+#define ALIGNED(t,v,n)  __declspec(align(n)) t v
 #define ALWAYS_INLINE	__forceinline
 #define NOINLINE		__declspec(noinline)
 #define THREADLOCAL		__declspec(thread)
@@ -109,8 +109,12 @@ static inline int clz64(uint64_t x) { unsigned long z;   _BitScanReverse64(&z, x
 #define bswap32(x) _byteswap_ulong(x)
 #define bswap64(x) _byteswap_uint64(x)
 
-#define popcnt32(x) __popcnt(x) 
+#define popcnt32(x) __popcnt(x)
+#ifdef _WIN64
 #define popcnt64(x) __popcnt64(x)
+#else
+#define popcnt64(x) (popcnt32(x) + popcnt32(x>>32))
+#endif
 
 #define sleep(x)    Sleep(x/1000)
 #define fseeko      _fseeki64

--- a/fp.c
+++ b/fp.c
@@ -40,7 +40,11 @@
 #define bitflush(   _bw_,_br_,_op_)      ctou64(_op_) = _bw_, _op_ += (_br_+7)>>3, _bw_=_br_=0
 
   #ifdef __AVX2__
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#include <intrin.h>
+#else
 #include <x86intrin.h>
+#endif
   #else
 #define _bzhi_u64(_u_, _b_)              ((_u_) & ((1ull<<(_b_))-1))
 #define _bzhi_u32(_u_, _b_)              ((_u_) & ((1u  <<(_b_))-1))

--- a/transpose.c
+++ b/transpose.c
@@ -120,7 +120,9 @@
 #include "transpose.c"
 
 //--------------------- CPU detection -------------------------------------------
-#if (_MSC_VER >=1300) || defined (__INTEL_COMPILER)
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#include <intrin.h>
+#elif defined(__INTEL_COMPILER)
 #include <x86intrin.h>
 #endif
 

--- a/transpose_avx2.c
+++ b/transpose_avx2.c
@@ -1,0 +1,2 @@
+#define AVX2_ON
+#include "transpose.c"

--- a/transpose_sse.c
+++ b/transpose_sse.c
@@ -1,0 +1,2 @@
+#define SSE2_ON
+#include "transpose.c"

--- a/vp4c_avx2.c
+++ b/vp4c_avx2.c
@@ -1,0 +1,2 @@
+#define AVX2_ON
+#include "vp4c.c"

--- a/vp4c_sse.c
+++ b/vp4c_sse.c
@@ -1,0 +1,2 @@
+#define SSE2_ON
+#include "vp4c.c"

--- a/vp4d.c
+++ b/vp4d.c
@@ -371,7 +371,7 @@ ALWAYS_INLINE unsigned char *TEMPLATE2(_P4DEC, USIZE)(unsigned char *__restrict 
 }
 
 unsigned char *TEMPLATE2(P4DEC, USIZE)(unsigned char *__restrict in, unsigned n, uint_t *__restrict out P4DELTA(uint_t start) ) {   
-  unsigned b, bx, i;  
+  unsigned b, bx = 0, i;  
   if(!n) return in;
   b = *in++;
   if((b & 0xc0) == 0xc0) {  // all items are equal
@@ -431,7 +431,7 @@ size_t TEMPLATE2(P4NDEC, USIZE)(unsigned char *__restrict in, size_t n, uint_t *
   --n;
     #endif
   for(op = out; op != out+(n&~(CSIZE-1)); op += CSIZE) {            
-    unsigned b = *ip++, bx, i;  										 __builtin_prefetch(ip+512);//ip = TEMPLATE2(P4DEC, USIZE)(ip, CSIZE, op P4DELTA(start));
+    unsigned b = *ip++, bx = 0, i;  										 __builtin_prefetch(ip+512);//ip = TEMPLATE2(P4DEC, USIZE)(ip, CSIZE, op P4DELTA(start));
 	
     if((b & 0xc0) == 0xc0) {
 	  b &= 0x3f;

--- a/vp4d_avx2.c
+++ b/vp4d_avx2.c
@@ -1,0 +1,2 @@
+#define AVX2_ON
+#include "vp4d.c"

--- a/vp4d_sse.c
+++ b/vp4d_sse.c
@@ -1,0 +1,2 @@
+#define SSE2_ON
+#include "vp4d.c"


### PR DESCRIPTION
1) is totally required to be able to compile with MS visual studio.
2) a minor fix that for unused variable access. It breaks debug build of VS where debugger aborts on uninitialized use of bx variable
3) is optional addition of sse/avx2 wrappers. These are required for those who need to compile directly with Visual Studio, as you cannot use the same file to produce different outputs with different compilation flags.

2) and 3) are up to you to include/cherry pick