### PR TITLE
docs: fix simple typo, genaral -> general

### DIFF
--- a/fp.c
+++ b/fp.c
@@ -33,7 +33,7 @@
 #include "bitutil.h"
 #include "fp.h"
 
-// ------------------ bitio genaral macros ---------------------------
+// ------------------ bitio general macros ---------------------------
   #ifdef __AVX2__
     #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #include <intrin.h>


### PR DESCRIPTION
There is a small typo in fp.c.

Should read `general` rather than `genaral`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md