### PR TITLE
Fix misleading indentation

### DIFF
--- a/lib/bitpack.c
+++ b/lib/bitpack.c
@@ -223,7 +223,8 @@ typedef unsigned char *(*BITPACK_D64)(uint64_t *__restrict out, unsigned n, cons
   for(ip = in, in += n; ip < in;) { \
     T3(uint, _usize_, _t) o,x;\
     unsigned iplen = in - ip,b; \
-    if(iplen > _csize_) iplen = _csize_;                                        PREFETCH(ip+512,0);\
+    if(iplen > _csize_) iplen = _csize_; \
+    PREFETCH(ip+512,0);\
     o = T2(bit,_usize_)(ip, iplen, &x); b = T2(bsr,_usize_)(o);\
     *op++ = b; op = T2(bitpacka, _usize_)[b](ip, iplen, op);\
     ip += iplen;\

--- a/lib/trled.c
+++ b/lib/trled.c
@@ -356,14 +356,22 @@ unsigned T2(_srled, USIZE)(const unsigned char *__restrict in, unsigned char *__
       op += r;
       ip += (r+1)*sizeof(uint_t);                                               PREFETCH(ip+512, 0);
        #else
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;
-    if(((c = ctout(ip)) == e)) goto a;        ip += sizeof(uint_t); *op++ = c;          PREFETCH(ip +512, 0);
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;
+    if(((c = ctout(ip)) == e)) goto a;
+    ip += sizeof(uint_t); *op++ = c;                                            PREFETCH(ip +512, 0);
     continue;
     a: ip += sizeof(uint_t);                                                    PREFETCH(ip +512, 0);
        #endif

--- a/lib/vp4c.c
+++ b/lib/vp4c.c
@@ -377,7 +377,8 @@ unsigned char *T2(_P4ENC, USIZE)(uint_t *__restrict in, unsigned n, unsigned cha
     #if HYBRID > 0 && USIZE >= 16
   if(bx <= USIZE) {
     #endif
-    for(i = 0; i < (n+63)/64; i++) ctou64(out+i*8) = xmap[i];     out += PAD8(n);   //if(eqx == xn && bx) { out[-1] |=0x80; T2(ctou, USIZE)(out)=ax; out += (bx+7)/8; } else
+    for(i = 0; i < (n+63)/64; i++) ctou64(out+i*8) = xmap[i];            //if(eqx == xn && bx) { out[-1] |=0x80; T2(ctou, USIZE)(out)=ax; out += (bx+7)/8; } else
+    out += PAD8(n);
     out = T2(bitpack, USIZE)(inx, xn, out, bx);                          //if(eq == n && b) { out[-1]|= 0x80; T2(ctou, USIZE)(out)=a; out += (b+7)/8; } else
     out = T2(BITPACK, USIZE)(_in, n,  out, b);
     #if HYBRID > 0 && USIZE >= 16

--- a/lib/vsimple.c
+++ b/lib/vsimple.c
@@ -453,7 +453,8 @@ unsigned char *T2(VSDEC, USIZE)(unsigned char *__restrict ip, size_t n, uint_t *
           unsigned b = ((*ip++) >> 5)+1;
           *op = *(unsigned long long *)ip;
           if(unlikely(b!=8))
-            *op &= (1ull<<(b*8))-1;         op++; ip += b;
+            *op &= (1ull<<(b*8))-1;
+                                            op++; ip += b;
           break;
         }
           #endif


### PR DESCRIPTION
Fixes the following warning with clang:
```
1>../../vsimple.c(456,45): warning : misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
```