### PR TITLE
Use proper typedef for uint64_t

### DIFF
--- a/lib/include_/time_.h
+++ b/lib/include_/time_.h
@@ -29,7 +29,7 @@
     #ifndef sleep
 #define sleep(n) Sleep((n) * 1000)
     #endif
-#define uint64_t unsigned __int64
+typedef unsigned long long uint64_t;
 
   #else
 #include <stdint.h>


### PR DESCRIPTION
Depending on order of includes using define causes errors