### PR TITLE
Fix include path, add missing headers in rc.c - corrected

### DIFF
--- a/lib/ext/rc.c
+++ b/lib/ext/rc.c
@@ -78,7 +78,7 @@ void rc_set_size(int size)
 	this->block_size = size;
 }*/
 //void pack(unsigned int *v, unsigned int b, unsigned int n, unsigned int *w);
-#include "../include/bitpack.h"
+#include "../include_/bitpack.h"
 #include "rc.h"
 
 	void setBit(unsigned char *buf, unsigned int *bp, unsigned int val)


### PR DESCRIPTION
corrected path for `include_` vs `include`